### PR TITLE
fix: ensure only messages from the bot are checked

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,3 +1,8 @@
+import dotenv from 'dotenv';
 import { alertChannel, getEnv } from './lib';
 
-alertChannel('general', getEnv());
+dotenv.config();
+
+const { ENV_CHANNEL = 'general' } = process.env;
+
+alertChannel(ENV_CHANNEL, getEnv());

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm-run-all --parallel clean bundle",
     "build:start": "npm run build -- start",
     "dev": "nodemon --ext ts --exec 'npm run build:start'",
+    "_dev": "nodemon --ext ts --exec 'npm run build && node dist/cli.js'",
     "start": "node dist/cli.js"
   },
   "repository": {


### PR DESCRIPTION
#### What does this PR do?

Adds functionality to ensure only messages from the bot to the `env channel` are checked before making the comparison for whether or not to upload updated env.

#### How should this be manually tested?

##### Before testing this fix:

👉🏾 Fire up the cli
👉🏾 go to the channel on slack where the env got sync to and post a new message there
👉🏾 fire up the cli again and see that the env would be updated again even if nothing actually changes in the file

##### To test this fix:

🔥 pull the branch
🔥 fire up the cli to sync env
🔥 post messages into the env channel
🔥 fire up the cli again – nothing should be uploaded
