### PR TITLE
upload new env file when values change 🔥

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -81,6 +81,7 @@ export const getEnv = (path: string = '.env') => {
 };
 
 const keys = (obj: {}): string[] => Object.keys(obj);
+const values = (obj: {}): string[] => Object.values(obj);
 
 export const alertChannel = async (channelName: string, file: Buffer) => {
   try {
@@ -105,8 +106,14 @@ export const alertChannel = async (channelName: string, file: Buffer) => {
       const variables = keys(localEnv).every(key =>
         slackEnv.hasOwnProperty(key)
       );
-      const inSync =
+      const keysInSync =
         variables && keys(localEnv).length === keys(slackEnv).length;
+
+      const valuesInSync =
+        new Set([...values(localEnv), ...values(slackEnv)]).size ===
+        values(localEnv).length;
+
+      const inSync = keysInSync && valuesInSync;
 
       fs.unlinkSync(filename);
 


### PR DESCRIPTION
### What does this PR do? 💪🏾💪🏾💪🏾

Adds functionality to also upload an updated `env` file when the values in the local `.env` file changes.

#### Context 👇🏾👇🏾👇🏾

Currently, new file upload is only triggered when the **keys** in your local environment variables changes, not so much so when the values change.

Per my understanding from the call we had, this shouldn't be the case as if the value of an environment variable would be changing, the team **should** also be notified.

This is what this PR solves for.

### How should this be manually tested?

#### Before 😢

👉🏾 change the key of an env variable/or add a new variable, then run cli – slack updates 👌🏾
👉🏾 change the value of any of the env variables and run cli – slack doesn't update 🤷🏾‍♂️

#### Now 🤩

Pull the branch, then

👉🏾 change the key of an env variable/or add a new variable, then run cli – slack updates 👌🏾
👉🏾 change the value of any of the env variables and run cli – slack **still** updates 🔥🔥


