### PR TITLE
Load env

### DIFF
--- a/lib/bot.ts
+++ b/lib/bot.ts
@@ -3,7 +3,9 @@ import { Token, Channel, IFile } from './models';
 import Axios from 'axios';
 import tempWrite from 'temp-write';
 import { readFileSync } from 'fs';
+import dotenv from 'dotenv';
 
+dotenv.config();
 const { SLACK_BOT_TOKEN: botToken, SLACK_USER_TOKEN: userToken } = process.env;
 
 class SlackBot {


### PR DESCRIPTION
### What does this PR do?
Fixes a bug that fails load env into process.env before accessing it