### PR TITLE
feat(bot): Add fileType to uploaded file

### DIFF
--- a/lib/__test__/bot.spec.ts
+++ b/lib/__test__/bot.spec.ts
@@ -72,6 +72,7 @@ describe('SlackBot', () => {
       await SlackBot.upload(testData.fileContents, channel);
       expect(SlackBot.web.files.upload).toHaveBeenCalledWith({
         file,
+        fileType: "shell",
         channels: channel.name,
         filename: expect.any(String)
       });

--- a/lib/bot.ts
+++ b/lib/bot.ts
@@ -61,6 +61,7 @@ class SlackBot {
       return this.web.files.upload({
         filename: Date.now().toString(),
         file,
+        fileType: "shell",
         channels: channel.name
       });
     });


### PR DESCRIPTION
`.env` files are `shell` files. Adding a `fileType` specifying that will enable color-coding in Slack, which my team finds useful to distinguish between comments and variables.